### PR TITLE
add lg participants to weekly sms advert

### DIFF
--- a/export_kakuma_advert_contacts.py
+++ b/export_kakuma_advert_contacts.py
@@ -182,7 +182,7 @@ if __name__ == "__main__":
         }
 
     log.warning(f"Exporting {len(advert_contacts)} contacts to {contacts_csv_path}")
-    with open(f'{contacts_csv_path}.csv', "w") as f:
+    with open(contacts_csv_path, "w") as f:
         headers = ["URN:Tel", "Name", "Language"]
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()

--- a/export_kakuma_advert_contacts.py
+++ b/export_kakuma_advert_contacts.py
@@ -74,32 +74,6 @@ if __name__ == "__main__":
     swahili_uuids = set()
     all_uuids = set()
 
-    # Load listening group de-identified CSV files
-    listening_group_csvs = []
-    for listening_group_csv_url in pipeline_configuration.listening_group_csv_urls:
-        listening_group_csvs.append(listening_group_csv_url.split("/")[-1])
-
-    for listening_group_csv in listening_group_csvs:
-        with open(f'{data_dir}/Raw Data/{listening_group_csv}', "r", encoding='utf-8-sig') as f:
-            data = list(csv.DictReader(f))
-            log.info(f'Loaded {len(data)} listening group participants from {data_dir}/Raw Data/{listening_group_csv}')
-
-            # Add the lg avf-phone-uuids to their respective language set
-            for row in data:
-                all_uuids.add(row['avf-phone-uuid'])
-                if row['Language'] == 'orm':
-                    oromo_uuids.add(row['avf-phone-uuid'])
-                elif row['Language'] == 'apd':
-                    sudanese_juba_arabic_uuids.add(row['avf-phone-uuid'])
-                elif row['Language'] == 'tuv':
-                    turkana_uuids.add(row['avf-phone-uuid'])
-                elif row['Language'] == 'som':
-                    somali_uuids.add(row['avf-phone-uuid'])
-                elif row['Language'] == 'eng':
-                    english_uuids.add(row['avf-phone-uuid'])
-                else:
-                    swahili_uuids.add(row['avf-phone-uuid'])
-
     log.info(f'Searching for the participants uuids vis-a-vis` their manually labelled '
              f'demographic language response')
     for msg in messages:
@@ -125,6 +99,38 @@ if __name__ == "__main__":
                 english_uuids.add(msg['uid'])
         else:
             swahili_uuids.add(msg['uid'])
+
+    # Load all listening group de-identified CSV files
+    listening_group_csvs = []
+    for listening_group_csv_url in pipeline_configuration.listening_group_csv_urls:
+        listening_group_csvs.append(listening_group_csv_url.split("/")[-1])
+
+    for listening_group_csv in listening_group_csvs:
+        with open(f'{data_dir}/Raw Data/{listening_group_csv}', "r", encoding='utf-8-sig') as f:
+            data = list(csv.DictReader(f))
+            log.info(
+                f'Loaded {len(data)} listening group participants from {data_dir}/Raw Data/{listening_group_csv}')
+
+            # Add the lg avf-phone-uuids to their respective language set
+            for row in data:
+                if row['avf-phone-uuid'] in all_uuids: # because we are giving precedence to the participants manually
+                                                       # labeled language
+                    continue
+
+                all_uuids.add(row['avf-phone-uuid'])
+
+                if row['Language'] == 'orm':
+                    oromo_uuids.add(row['avf-phone-uuid'])
+                elif row['Language'] == 'apd':
+                    sudanese_juba_arabic_uuids.add(row['avf-phone-uuid'])
+                elif row['Language'] == 'tuv':
+                    turkana_uuids.add(row['avf-phone-uuid'])
+                elif row['Language'] == 'som':
+                    somali_uuids.add(row['avf-phone-uuid'])
+                elif row['Language'] == 'eng':
+                    english_uuids.add(row['avf-phone-uuid'])
+                else:
+                    swahili_uuids.add(row['avf-phone-uuid'])
 
     # Convert the uuids to phone numbers
     log.info("Converting the uuids to phone numbers...")

--- a/export_kakuma_advert_contacts.py
+++ b/export_kakuma_advert_contacts.py
@@ -27,17 +27,15 @@ if __name__ == "__main__":
     parser.add_argument("data_dir", metavar="data-dir",
                         help="Directory path to read messages traced data JSONL file + listening group CSV files "
                              "to extract phone from, and write the advert CSV file to")
-    parser.add_argument("sms_ad_flow_name", metavar="sms-ad-flow-name",
-                        help="The name of the advert flow we are triggering the contacts to i.e "
-                             "sms ad flow name for the radio show currently airing. The string format for this project is "
-                             "<kakuma_so{n}_e0{n}_sms_ad>")
+    parser.add_argument("contacts_csv_path", metavar="contacts-csv-path",
+                        help="CSV file path to write the contacts data to")
 
     args = parser.parse_args()
 
     google_cloud_credentials_file_path = args.google_cloud_credentials_file_path
     pipeline_configuration_file_path = args.pipeline_configuration_file_path
     data_dir = args.data_dir
-    sms_ad_flow_name = args.sms_ad_flow_name
+    contacts_csv_path = args.contacts_csv_path
 
     # Read the settings from the configuration file
     log.info("Loading Pipeline Configuration File...")
@@ -183,12 +181,12 @@ if __name__ == "__main__":
             "Language": 'swh'
         }
 
-    log.warning(f"Exporting {len(advert_contacts)} contacts to {data_dir}")
-    with open(f'{data_dir}/Outputs/{sms_ad_flow_name}.csv', "w") as f:
+    log.warning(f"Exporting {len(advert_contacts)} contacts to {contacts_csv_path}")
+    with open(f'{contacts_csv_path}.csv', "w") as f:
         headers = ["URN:Tel", "Name", "Language"]
         writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
         writer.writeheader()
         for phone_number in advert_contacts.values():
             writer.writerow(phone_number)
 
-        log.info(f"Wrote {len(advert_contacts)} contacts to {data_dir}/Outputs/{sms_ad_flow_name}.csv")
+        log.info(f"Wrote {len(advert_contacts)} contacts to {contacts_csv_path}")

--- a/export_kakuma_advert_contacts.py
+++ b/export_kakuma_advert_contacts.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
     for listening_group_csv in listening_group_csvs:
         with open(f'{data_dir}/Raw Data/{listening_group_csv}', "r", encoding='utf-8-sig') as f:
             data = list(csv.DictReader(f))
-            log.info(f'Loaded {len(data)} ' f'{data_dir}/Raw Data/{listening_group_csv} listening group participants')
+            log.info(f'Loaded {len(data)} listening group participants from {data_dir}/Raw Data/{listening_group_csv}')
 
             # Add the lg avf-phone-uuids to their respective language set
             for row in data:


### PR DESCRIPTION
Ideally, all the lg participants should have sent a message but that is not always the case. This allows us to advertise to all listening to group participants by adding them to the weekly SMS ad CSV file. 
 + other minor code and args refactor. 