### PR TITLE
always download listening group files

### DIFF
--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -92,11 +92,6 @@ def fetch_listening_groups_csvs(google_cloud_credentials_file_path, pipeline_con
     for listening_group_csv_url in pipeline_configuration.listening_group_csv_urls:
         listening_group = listening_group_csv_url.split("/")[-1]
 
-        if os.path.exists(f'{raw_data_dir}/{listening_group}'):
-            log.info(
-                f"File '{raw_data_dir}' for '{listening_group}' already exists; skipping download")
-            continue
-
         log.info(f"Saving '{listening_group}' to file '{raw_data_dir}'...")
         with open(f'{raw_data_dir}/{listening_group}', "wb") as listening_group_output_file:
             google_cloud_utils.download_blob_to_file(


### PR DESCRIPTION
We are regularly updating old listening group files to match the correct phone number as some participants initially give the phone numbers that they did not use to text us. Therefore the need to fetch new files from gs on each pipeline run. 