### PR TITLE
Support follow ups

### DIFF
--- a/code_schemes/dadaab_encouragement_for_boys.json
+++ b/code_schemes/dadaab_encouragement_for_boys.json
@@ -128,7 +128,8 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
-    },{
+    },
+    {
       "CodeID": "code-SC-a3a065bc",
       "CodeType": "Meta",
       "MetaCode": "similar_content",

--- a/code_schemes/dadaab_encouragement_for_boys.json
+++ b/code_schemes/dadaab_encouragement_for_boys.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-35262cee",
+  "Name": "DADAAB Encouragement For Boys",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/dadaab_encouragement_for_boys.json
+++ b/code_schemes/dadaab_encouragement_for_boys.json
@@ -128,6 +128,23 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },{
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_girls_education_champions.json
+++ b/code_schemes/dadaab_girls_education_champions.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_girls_education_champions.json
+++ b/code_schemes/dadaab_girls_education_champions.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-305a8bcf",
+  "Name": "DADAAB Girls Education Champions",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/dadaab_lessons_learnt.json
+++ b/code_schemes/dadaab_lessons_learnt.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-1de33d9a",
+  "Name": "DADAAB Lessons Learnt",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/dadaab_lessons_learnt.json
+++ b/code_schemes/dadaab_lessons_learnt.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_s01_intro_reasons.json
+++ b/code_schemes/dadaab_s01_intro_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_s01e01_reasons.json
+++ b/code_schemes/dadaab_s01e01_reasons.json
@@ -208,6 +208,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_s01e02_reasons.json
+++ b/code_schemes/dadaab_s01e02_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_s01e03_reasons.json
+++ b/code_schemes/dadaab_s01e03_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_s01e04_reasons.json
+++ b/code_schemes/dadaab_s01e04_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_s01e05_reasons.json
+++ b/code_schemes/dadaab_s01e05_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_s01e06_reasons.json
+++ b/code_schemes/dadaab_s01e06_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_s01e07_reasons.json
+++ b/code_schemes/dadaab_s01e07_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_show_suggestions.json
+++ b/code_schemes/dadaab_show_suggestions.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_show_suggestions.json
+++ b/code_schemes/dadaab_show_suggestions.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-8641c108",
+  "Name": "DADAAB Show Suggestions",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/dadaab_unmarried_fathers_community_view.json
+++ b/code_schemes/dadaab_unmarried_fathers_community_view.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/dadaab_unmarried_fathers_community_view.json
+++ b/code_schemes/dadaab_unmarried_fathers_community_view.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-b29b6a7d",
+  "Name": "DADAAB Unmarried Fathers Community View",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/dadaab_ws_correct_dataset.json
+++ b/code_schemes/dadaab_ws_correct_dataset.json
@@ -136,6 +136,61 @@
       ]
     },
     {
+      "CodeID": "code-62e86a77",
+      "CodeType": "Normal",
+      "DisplayText": "dadaab girls education champions",
+      "StringValue": "dadaab_girls_education_champions",
+      "NumericValue": 24,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dadaab girls education champions"
+      ]
+    },
+    {
+      "CodeID": "code-e24f1e4a",
+      "CodeType": "Normal",
+      "DisplayText": "dadaab encouragement for boys",
+      "StringValue": "dadaab_encouragement_for_boys",
+      "NumericValue": 25,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dadaab encouragement for boys"
+      ]
+    },
+    {
+      "CodeID": "code-5c606074",
+      "CodeType": "Normal",
+      "DisplayText": "dadaab unmarried fathers community view",
+      "StringValue": "dadaab_unmarried_fathers_community_view",
+      "NumericValue": 26,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dadaab unmarried fathers community view"
+      ]
+    },
+    {
+      "CodeID": "code-90616cb5",
+      "CodeType": "Normal",
+      "DisplayText": "dadaab lessons learnt",
+      "StringValue": "dadaab_lessons_learnt",
+      "NumericValue": 27,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dadaab lessons learnt"
+      ]
+    },
+    {
+      "CodeID": "code-e3c25a49",
+      "CodeType": "Normal",
+      "DisplayText": "dadaab show suggestions",
+      "StringValue": "dadaab_show_suggestions",
+      "NumericValue": 27,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "dadaab show suggestions"
+      ]
+    },
+    {
       "CodeID": "code-NC-42f1d983",
       "CodeType": "Control",
       "ControlCode": "NC",

--- a/code_schemes/kakuma_encouragement_for_boys.json
+++ b/code_schemes/kakuma_encouragement_for_boys.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_encouragement_for_boys.json
+++ b/code_schemes/kakuma_encouragement_for_boys.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-72929fe1",
+  "Name": "KAKUMA Education For Boys",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/kakuma_girls_education_champions.json
+++ b/code_schemes/kakuma_girls_education_champions.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_girls_education_champions.json
+++ b/code_schemes/kakuma_girls_education_champions.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-20e1de24",
+  "Name": "KAKUMA Girls Education Champions",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/kakuma_lessons_learnt.json
+++ b/code_schemes/kakuma_lessons_learnt.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_lessons_learnt.json
+++ b/code_schemes/kakuma_lessons_learnt.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-7dc4d7a2",
+  "Name": "KAKUMA Lessons Learnt",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/kakuma_s01_intro_reasons.json
+++ b/code_schemes/kakuma_s01_intro_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_s01e01_reasons.json
+++ b/code_schemes/kakuma_s01e01_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_s01e02_reasons.json
+++ b/code_schemes/kakuma_s01e02_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_s01e03_reasons.json
+++ b/code_schemes/kakuma_s01e03_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_s01e04_reasons.json
+++ b/code_schemes/kakuma_s01e04_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_s01e05_reasons.json
+++ b/code_schemes/kakuma_s01e05_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_s01e06_reasons.json
+++ b/code_schemes/kakuma_s01e06_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_s01e07_reasons.json
+++ b/code_schemes/kakuma_s01e07_reasons.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_show_suggestions.json
+++ b/code_schemes/kakuma_show_suggestions.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_show_suggestions.json
+++ b/code_schemes/kakuma_show_suggestions.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-1839c8b5",
+  "Name": "KAKUMA Show Suggestions",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/kakuma_unmarried_fathers_community_view.json
+++ b/code_schemes/kakuma_unmarried_fathers_community_view.json
@@ -128,6 +128,24 @@
       "NumericValue": -100040,
       "StringValue": "opt_in",
       "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
     }
   ]
 }

--- a/code_schemes/kakuma_unmarried_fathers_community_view.json
+++ b/code_schemes/kakuma_unmarried_fathers_community_view.json
@@ -1,0 +1,133 @@
+{
+  "SchemeID": "Scheme-0b312cda",
+  "Name": "KAKUMA Unmarried Fathers Community View",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/kakuma_ws_correct_dataset.json
+++ b/code_schemes/kakuma_ws_correct_dataset.json
@@ -136,6 +136,61 @@
       ]
     },
     {
+      "CodeID": "code-b03a8d5c",
+      "CodeType": "Normal",
+      "DisplayText": "kakuma girls education champions",
+      "StringValue": "kakuma_girls_education_champions",
+      "NumericValue": 24,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kakuma girls education champions"
+      ]
+    },
+    {
+      "CodeID": "code-c93519aa",
+      "CodeType": "Normal",
+      "DisplayText": "kakuma encouragement for boys",
+      "StringValue": "kakuma_encouragement_for_boys",
+      "NumericValue": 25,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kakuma encouragement for boys"
+      ]
+    },
+    {
+      "CodeID": "code-77ef8619",
+      "CodeType": "Normal",
+      "DisplayText": "kakuma unmarried fathers community view",
+      "StringValue": "kakuma_unmarried_fathers_community_view",
+      "NumericValue": 26,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kakuma unmarried fathers community view"
+      ]
+    },
+    {
+      "CodeID": "code-e4a281b8",
+      "CodeType": "Normal",
+      "DisplayText": "kakuma lessons learnt",
+      "StringValue": "kakuma_lessons_learnt",
+      "NumericValue": 27,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kakuma lessons learnt"
+      ]
+    },
+    {
+      "CodeID": "code-9b2cb541",
+      "CodeType": "Normal",
+      "DisplayText": "kakuma show suggestions",
+      "StringValue": "kakuma_show_suggestions",
+      "NumericValue": 27,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "kakuma show suggestions"
+      ]
+    },
+    {
       "CodeID": "code-NC-42f1d983",
       "CodeType": "Control",
       "ControlCode": "NC",

--- a/configurations/dadaab_pipeline_config.json
+++ b/configurations/dadaab_pipeline_config.json
@@ -19,7 +19,7 @@
         "wusc_keep_ii_s01_w3_dadaab_follow_up",
         "wusc_keep_ii_s01_w4_dadaab_follow_up",
         "wusc_keep_ii_s01_w6_dadaab_follow_up",
-        "kakuma_s01_evaluation_flow"
+        "dadaab_s01_evaluation_flow"
       ],
       "TestContactUUIDs": [
         "f3e07a4a-4c5d-4032-80f3-c31bcf480dc9",

--- a/configurations/dadaab_pipeline_config.json
+++ b/configurations/dadaab_pipeline_config.json
@@ -18,8 +18,7 @@
         "wusc_keep_ii_dadaab_demogs",
         "wusc_keep_ii_s01_w3_dadaab_follow_up",
         "wusc_keep_ii_s01_w4_dadaab_follow_up",
-        "wusc_keep_ii_s01_w6_dadaab_follow_up",
-        "dadaab_s01_evaluation_flow"
+        "wusc_keep_ii_s01_w6_dadaab_follow_up"
       ],
       "TestContactUUIDs": [
         "f3e07a4a-4c5d-4032-80f3-c31bcf480dc9",

--- a/configurations/dadaab_pipeline_config.json
+++ b/configurations/dadaab_pipeline_config.json
@@ -15,7 +15,11 @@
         "wusc_keep_ii_s01_e07_dadaab_activation"
       ],
       "SurveyFlowNames": [
-        "wusc_keep_ii_dadaab_demogs"
+        "wusc_keep_ii_dadaab_demogs",
+        "wusc_keep_ii_s01_w3_dadaab_follow_up",
+        "wusc_keep_ii_s01_w4_dadaab_follow_up",
+        "wusc_keep_ii_s01_w6_dadaab_follow_up",
+        "kakuma_s01_evaluation_flow"
       ],
       "TestContactUUIDs": [
         "f3e07a4a-4c5d-4032-80f3-c31bcf480dc9",
@@ -68,7 +72,19 @@
     {"RapidProKey": "Age (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "age_time"},
     {"RapidProKey": "Location (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "location_time"},
     {"RapidProKey": "Nationality (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "nationality_time"},
-    {"RapidProKey": "Household_Language (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "household_language_time"}
+    {"RapidProKey": "Household_Language (Time) - wusc_keep_ii_dadaab_demogs", "PipelineKey": "household_language_time"},
+    
+    {"RapidProKey": "Girls_Education_Champions (Text) - wusc_keep_ii_s01_w3_dadaab_follow_up", "PipelineKey": "girls_education_champions_raw"},
+    {"RapidProKey": "Encouragement_For_Boys (Text) - wusc_keep_ii_s01_w4_dadaab_follow_up", "PipelineKey": "encouragement_for_boys_raw"},
+    {"RapidProKey": "Unmarried_Fathers_Community_View (Text) - wusc_keep_ii_s01_w6_dadaab_follow_up", "PipelineKey": "unmarried_fathers_community_view_raw"},
+    {"RapidProKey": "Lessons_Learnt (Text) - dadaab_s01_evaluation_flow", "PipelineKey": "lessons_learnt_raw"},
+    {"RapidProKey": "Show_Suggestions (Text) - dadaab_s01_evaluation_flow", "PipelineKey": "show_suggestions_raw"},
+
+    {"RapidProKey": "Girls_Education_Champions (Time) - wusc_keep_ii_s01_w3_dadaab_follow_up", "PipelineKey": "girls_education_champions_time"},
+    {"RapidProKey": "Encouragement_For_Boys (Time) - wusc_keep_ii_s01_w4_dadaab_follow_up", "PipelineKey": "encouragement_for_boys_time"},
+    {"RapidProKey": "Unmarried_Fathers_Community_View (Time) - wusc_keep_ii_s01_w6_dadaab_follow_up", "PipelineKey": "unmarried_fathers_community_view_time"},
+    {"RapidProKey": "Lessons_Learnt (Time) - dadaab_s01_evaluation_flow", "PipelineKey": "lessons_learnt_time"},
+    {"RapidProKey": "Show_Suggestions (Time) - dadaab_s01_evaluation_flow", "PipelineKey": "show_suggestions_time"}
   ],
   "PipelineName": "dadaab_pipeline",
   "ProjectStartDate": "2020-02-06T08:20:00+03:00",

--- a/configurations/kakuma_pipeline_config.json
+++ b/configurations/kakuma_pipeline_config.json
@@ -15,7 +15,11 @@
         "wusc_keep_ii_s01_e07_kakuma_activation"
       ],
       "SurveyFlowNames": [
-        "wusc_keep_ii_kakuma_demogs"
+        "wusc_keep_ii_kakuma_demogs",
+        "wusc_keep_ii_s01_w3_kakuma_follow_up",
+        "wusc_keep_ii_s01_w4_kakuma_follow_up",
+        "wusc_keep_ii_s01_w6_kakuma_follow_up",
+        "kakuma_s01_evaluation_flow"
       ],
       "TestContactUUIDs": [
         "84f1c3bc-596e-455e-b5f6-ce16640e9b95",
@@ -75,7 +79,19 @@
     {"RapidProKey": "Age (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "age_time"},
     {"RapidProKey": "Location (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "location_time"},
     {"RapidProKey": "Nationality (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "nationality_time"},
-    {"RapidProKey": "Household_Language (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "household_language_time"}
+    {"RapidProKey": "Household_Language (Time) - wusc_keep_ii_kakuma_demogs", "PipelineKey": "household_language_time"},
+
+    {"RapidProKey": "Girls_Education_Champions (Text) - wusc_keep_ii_s01_w3_kakuma_follow_up", "PipelineKey": "girls_education_champions_raw"},
+    {"RapidProKey": "Encouragement_For_Boys (Text) - wusc_keep_ii_s01_w4_kakuma_follow_up", "PipelineKey": "encouragement_for_boys_raw"},
+    {"RapidProKey": "Unmarried_Fathers_Community_View (Text) - wusc_keep_ii_s01_w6_kakuma_follow_up", "PipelineKey": "unmarried_fathers_community_view_raw"},
+    {"RapidProKey": "Lessons_Learnt (Text) - kakuma_s01_evaluation_flow", "PipelineKey": "lessons_learnt_raw"},
+    {"RapidProKey": "Show_Suggestions (Text) - kakuma_s01_evaluation_flow", "PipelineKey": "show_suggestions_raw"},
+
+    {"RapidProKey": "Girls_Education_Champions (Time) - wusc_keep_ii_s01_w3_kakuma_follow_up", "PipelineKey": "girls_education_champions_time"},
+    {"RapidProKey": "Encouragement_For_Boys (Time) - wusc_keep_ii_s01_w4_kakuma_follow_up", "PipelineKey": "encouragement_for_boys_time"},
+    {"RapidProKey": "Unmarried_Fathers_Community_View (Time) - wusc_keep_ii_s01_w6_kakuma_follow_up", "PipelineKey": "unmarried_fathers_community_view_time"},
+    {"RapidProKey": "Lessons_Learnt (Time) - kakuma_s01_evaluation_flow", "PipelineKey": "lessons_learnt_time"},
+    {"RapidProKey": "Show_Suggestions (Time) - kakuma_s01_evaluation_flow", "PipelineKey": "show_suggestions_time"}
   ],
   "PipelineName": "kakuma_pipeline",
   "ProjectStartDate": "2020-01-18T13:00:00+03:00",

--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -30,6 +30,12 @@ DATASETS=(
     "kakuma_nationality"
     "kakuma_household_language"
 
+    "kakuma_girls_education_champions"
+    "kakuma_encouragement_for_boys"
+    "kakuma_unmarried_fathers_community_view"
+    "kakuma_lessons_learnt"
+    "kakuma_show_suggestions"
+
     "dadaab_s01e01"
     "dadaab_s01e02"
     "dadaab_s01e03"
@@ -43,6 +49,12 @@ DATASETS=(
     "dadaab_age"
     "dadaab_nationality"
     "dadaab_household_language"
+
+    "dadaab_girls_education_champions"
+    "dadaab_encouragement_for_boys"
+    "dadaab_unmarried_fathers_community_view"
+    "dadaab_lessons_learnt"
+    "dadaab_show_suggestions"
 )
 
 cd "$CODA_V2_ROOT/data_tools"

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -30,6 +30,12 @@ DATASETS=(
     "kakuma_age"
     "kakuma_nationality"
     "kakuma_household_language"
+    
+    "kakuma_girls_education_champions"
+    "kakuma_encouragement_for_boys"
+    "kakuma_unmarried_fathers_community_view"
+    "kakuma_lessons_learnt"
+    "kakuma_show_suggestions"
 
     "dadaab_s01e01"
     "dadaab_s01e02"
@@ -44,6 +50,12 @@ DATASETS=(
     "dadaab_age"
     "dadaab_nationality"
     "dadaab_household_language"
+    
+    "dadaab_girls_education_champions"
+    "dadaab_encouragement_for_boys"
+    "dadaab_unmarried_fathers_community_view"
+    "dadaab_lessons_learnt"
+    "dadaab_show_suggestions"
 )
 
 cd "$CODA_V2_ROOT/data_tools"

--- a/src/lib/code_schemes.py
+++ b/src/lib/code_schemes.py
@@ -34,6 +34,18 @@ class CodeSchemes(object):
     KAKUMA_HOUSEHOLD_LANGUAGE = _open_scheme("kakuma_household_language.json")
     KAKUMA_LOCATION = _open_scheme("kakuma_location.json")
 
+    DADAAB_GIRLS_EDUCATION_CHAMPIONS = _open_scheme("dadaab_girls_education_champions.json")
+    DADAAB_ENCOURAGEMENT_FOR_BOYS_CHAMPIONS = _open_scheme("dadaab_encouragement_for_boys.json")
+    DADAAB_UNMARRIED_FATHERS_COMMUNITY_VIEW = _open_scheme("dadaab_unmarried_fathers_community_view.json")
+    DADAAB_LESSONS_LEARNT = _open_scheme("dadaab_lessons_learnt.json")
+    DADAAB_SHOW_SUGGESTIONS = _open_scheme("dadaab_show_suggestions.json")
+
+    KAKUMA_GIRLS_EDUCATION_CHAMPIONS = _open_scheme("kakuma_girls_education_champions.json")
+    KAKUMA_ENCOURAGEMENT_FOR_BOYS_CHAMPIONS = _open_scheme("kakuma_encouragement_for_boys.json")
+    KAKUMA_UNMARRIED_FATHERS_COMMUNITY_VIEW = _open_scheme("kakuma_unmarried_fathers_community_view.json")
+    KAKUMA_LESSONS_LEARNT = _open_scheme("kakuma_lessons_learnt.json")
+    KAKUMA_SHOW_SUGGESTIONS = _open_scheme("kakuma_show_suggestions.json")
+
     WS_CORRECT_DATASET = None
     KAKUMA_WS_CORRECT_DATASET = _open_scheme("kakuma_ws_correct_dataset.json")
     DADAAB_WS_CORRECT_DATASET = _open_scheme("dadaab_ws_correct_dataset.json")

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -415,7 +415,92 @@ class PipelineConfiguration(object):
                        )
                    ],
                    ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value("kakuma nationality"),
-                   raw_field_fold_strategy=FoldStrategies.assert_equal)
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="girls_education_champions_raw",
+                   dataset_name="kakuma_girls_education_champions",
+                   time_field="girls_education_champions_time",
+                   coda_filename="kakuma_girls_education_champions.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_GIRLS_EDUCATION_CHAMPIONS,
+                           coded_field="girls_education_champions_coded",
+                           analysis_file_key="girls_education_champions_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_GIRLS_EDUCATION_CHAMPIONS, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "kakuma girls education champions"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="encouragement_for_boys_raw",
+                   dataset_name="kakuma_encouragement_for_boys",
+                   time_field="encouragement_for_boys_time",
+                   coda_filename="kakuma_encouragement_for_boys.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_ENCOURAGEMENT_FOR_BOYS_CHAMPIONS,
+                           coded_field="encouragement_for_boys",
+                           analysis_file_key="encouragement_for_boys_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_ENCOURAGEMENT_FOR_BOYS_CHAMPIONS, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "kakuma encouragement for boys"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="unmarried_fathers_community_view_raw",
+                   dataset_name="kakuma_unmarried_fathers_community_view",
+                   time_field="unmarried_fathers_community_view_time",
+                   coda_filename="kakuma_unmarried_fathers_community_view.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_UNMARRIED_FATHERS_COMMUNITY_VIEW,
+                           coded_field="unmarried_fathers_community_view",
+                           analysis_file_key="unmarried_fathers_community_view_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_UNMARRIED_FATHERS_COMMUNITY_VIEW, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "kakuma unmarried fathers community view"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="lessons_learnt_raw",
+                   dataset_name="kakuma_lessons_learnt",
+                   time_field="lessons_learnt_time",
+                   coda_filename="kakuma_lessons_learnt.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_LESSONS_LEARNT,
+                           coded_field="lessons_learnt",
+                           analysis_file_key="lessons_learnt_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_LESSONS_LEARNT, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "kakuma lessons learnt"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="show_suggestions_raw",
+                   dataset_name="kakuma_show_suggestions",
+                   time_field="show_suggestions_time",
+                   coda_filename="kakuma_show_suggestions.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.KAKUMA_SHOW_SUGGESTIONS,
+                           coded_field="show_suggestions",
+                           analysis_file_key="show_suggestions_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.KAKUMA_SHOW_SUGGESTIONS, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.KAKUMA_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "kakuma show suggestions"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate)
     ]
 
     DADAAB_SURVEY_CODING_PLANS = [
@@ -500,7 +585,91 @@ class PipelineConfiguration(object):
                        )
                    ],
                    ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET.get_code_with_match_value("dadaab nationality"),
-                   raw_field_fold_strategy=FoldStrategies.assert_equal)
+                   raw_field_fold_strategy=FoldStrategies.assert_equal),
+
+        CodingPlan(raw_field="girls_education_champions_raw",
+                   dataset_name="dadaab_girls_education_champions",
+                   time_field="girls_education_champions_time",
+                   coda_filename="dadaab_girls_education_champions.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_GIRLS_EDUCATION_CHAMPIONS,
+                           coded_field="girls_education_champions_coded",
+                           analysis_file_key="girls_education_champions_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_GIRLS_EDUCATION_CHAMPIONS, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET.get_code_with_match_value("dadaab girls education champions"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="encouragement_for_boys_raw",
+                   dataset_name="dadaab_encouragement_for_boys",
+                   time_field="encouragement_for_boys_time",
+                   coda_filename="dadaab_encouragement_for_boys.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_ENCOURAGEMENT_FOR_BOYS_CHAMPIONS,
+                           coded_field="encouragement_for_boys",
+                           analysis_file_key="encouragement_for_boys_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_ENCOURAGEMENT_FOR_BOYS_CHAMPIONS, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "dadaab encouragement for boys"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="unmarried_fathers_community_view_raw",
+                   dataset_name="dadaab_unmarried_fathers_community_view",
+                   time_field="unmarried_fathers_community_view_time",
+                   coda_filename="dadaab_unmarried_fathers_community_view.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_UNMARRIED_FATHERS_COMMUNITY_VIEW,
+                           coded_field="girls_unmarried_fathers_community_view",
+                           analysis_file_key="girls_unmarried_fathers_community_view_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_UNMARRIED_FATHERS_COMMUNITY_VIEW, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "dadaab unmarried fathers community view"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="lessons_learnt_raw",
+                   dataset_name="dadaab_lessons_learnt",
+                   time_field="lessons_learnt_time",
+                   coda_filename="dadaab_lessons_learnt.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_LESSONS_LEARNT,
+                           coded_field="lessons_learnt",
+                           analysis_file_key="lessons_learnt_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_LESSONS_LEARNT, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "dadaab lessons learnt"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
+        CodingPlan(raw_field="show_suggestions_raw",
+                   dataset_name="dadaab_show_suggestions",
+                   time_field="show_suggestions_time",
+                   coda_filename="dadaab_show_suggestions.json",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.MULTIPLE,
+                           code_scheme=CodeSchemes.DADAAB_SHOW_SUGGESTIONS,
+                           coded_field="show_suggestions",
+                           analysis_file_key="show_suggestions_",
+                           fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.DADAAB_SHOW_SUGGESTIONS, x, y)
+                       )
+                   ],
+                   ws_code=CodeSchemes.DADAAB_WS_CORRECT_DATASET.get_code_with_match_value(
+                       "dadaab show suggestions"),
+                   raw_field_fold_strategy=FoldStrategies.concatenate)
     ]
 
     def __init__(self, raw_data_sources, phone_number_uuid_table, timestamp_remappings,


### PR DESCRIPTION
This adds support to both camps follow up surveys. They were initially not formulated by RDA during the initial pipeline setup.
PS- I have intentionally removed Dadaab evaluation flow since its not setup in Textit yet but the structure and variables will be as is in kakuma. I will add it later.
This includes many file changes but most of them are scheme placeholders and configuration. 