### PR TITLE
disable adding so1 datasets to coda

### DIFF
--- a/run_scripts/4_dadaab_coda_add.sh
+++ b/run_scripts/4_dadaab_coda_add.sh
@@ -17,14 +17,14 @@ DATA_ROOT=$3
 PROJECT_NAME="WUSC-KEEP-II"
 
 DATASETS=(
-    "dadaab_s01e01"
-    "dadaab_s01e02"
-    "dadaab_s01e03"
-    "dadaab_s01e04"
-    "dadaab_s01e05"
-    "dadaab_s01e06"
-    "dadaab_s01e07"
-    "dadaab_s01_intro"
+    #"dadaab_s01e01"
+    #"dadaab_s01e02"
+    #"dadaab_s01e03"
+    #"dadaab_s01e04"
+    #"dadaab_s01e05"
+    #"dadaab_s01e06"
+    #"dadaab_s01e07"
+    #"dadaab_s01_intro"
 
     "dadaab_s02e01"
     "dadaab_s02e02"
@@ -40,11 +40,11 @@ DATASETS=(
     "dadaab_nationality"
     "dadaab_household_language"
 
-    "dadaab_girls_education_champions"
-    "dadaab_encouragement_for_boys"
-    "dadaab_unmarried_fathers_community_view"
-    "dadaab_lessons_learnt"
-    "dadaab_show_suggestions"
+    #"dadaab_girls_education_champions"
+    #"dadaab_encouragement_for_boys"
+    #"dadaab_unmarried_fathers_community_view"
+    #"dadaab_lessons_learnt"
+    #"dadaab_show_suggestions"
 
     "dadaab_community_views_on_girls_education"
 )

--- a/run_scripts/4_kakuma_coda_add.sh
+++ b/run_scripts/4_kakuma_coda_add.sh
@@ -17,14 +17,14 @@ DATA_ROOT=$3
 PROJECT_NAME="WUSC-KEEP-II"
 
 DATASETS=(
-    "kakuma_s01e01"
-    "kakuma_s01e02"
-    "kakuma_s01e03"
-    "kakuma_s01e04"
-    "kakuma_s01e05"
-    "kakuma_s01e06"
-    "kakuma_s01e07"
-    "kakuma_s01_intro"
+    #"kakuma_s01e01"
+    #"kakuma_s01e02"
+    #"kakuma_s01e03"
+    #"kakuma_s01e04"
+    #"kakuma_s01e05"
+    #"kakuma_s01e06"
+    #"kakuma_s01e07"
+    #"kakuma_s01_intro"
 
     "kakuma_s02e01"
     "kakuma_s02e02"
@@ -40,11 +40,11 @@ DATASETS=(
     "kakuma_nationality"
     "kakuma_household_language"
 
-    "kakuma_girls_education_champions"
-    "kakuma_encouragement_for_boys"
-    "kakuma_unmarried_fathers_community_view"
-    "kakuma_lessons_learnt"
-    "kakuma_show_suggestions"
+    #"kakuma_girls_education_champions"
+    #"kakuma_encouragement_for_boys"
+    #"kakuma_unmarried_fathers_community_view"
+    #"kakuma_lessons_learnt"
+    #"kakuma_show_suggestions"
 
     "kakuma_community_views_on_girls_education"
 )


### PR DESCRIPTION
When running all-seasons or seasonal pipelines we don't need to push messages to coda for s01 datasets since this has been fully labeled.